### PR TITLE
Feature/csm 1.2 appversion

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -29,6 +29,7 @@ pipeline {
 
         stage("Chart") {
             steps {
+                updateCsmHelmChartAppVersion(chartPath: "${WORKSPACE}/kubernetes/${CHART_NAME}", appVersion:  env.VERSION)
                 sh "make chart"
             }
         }


### PR DESCRIPTION
### Summary and Scope

Added appVersion to Chart. Pete is on PTO today. He told me that csm-validate failed with:

```
-------------
20:59:57  ERROR!! MISSING Helm Image: cray:hms-discovery:latest

in replay:
added functional call to chart stage: updateCsmHelmChartAppVersion(chartPath: "${WORKSPACE}/kubernetes/${CHART_NAME}", appVersion:  env.VERSION)

-------------
20:59:57  ERROR!! MISSING Helm Image: cray:hms-trs-operator:latest

in replay:
added functional call to chart stage: updateCsmHelmChartAppVersion(chartPath: "${WORKSPACE}/kubernetes/${CHART_NAME}", appVersion:  env.VERSION)
```
Michael Jendrysik helped me test install and roll back on loki

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? Y

### Issues and Related PRs

* Resolves https://connect.us.cray.com/jira/browse/CASMHMS-5048

### Testing

LIST THE ENVIRONMENTS IN WHICH THESE CHANGES WERE TESTED.

Tested on:
* loki

Were the install/upgrade based validation checks/tests run? Y
Were continuous integration tests run? N
Was an Upgrade tested?                 N
Was a Downgrade tested?                N

### Risks and Mitigations

HAS A SECURITY AUDIT BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

